### PR TITLE
Dynamic PB

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -228,14 +227,14 @@ func (ds *DeadletterService) RejectDeadMessage(ctx context.Context, req *dante_s
 		}
 
 		deadProto := dante_pb.DeadMessageState{}
-		err = protojson.Unmarshal([]byte(deadletter), &deadProto)
+		err = ds.protojson.Unmarshal([]byte(deadletter), &deadProto)
 		if err != nil {
 			log.WithError(ctx, err).Error("Couldn't unmarshal dead letter")
 			return err
 		}
 		deadProto.Status = dante_pb.MessageStatus_MESSAGE_STATUS_REJECTED
 
-		msg_json, err := protojson.Marshal(&deadProto)
+		msg_json, err := ds.protojson.Marshal(&deadProto)
 		if err != nil {
 			log.Infof(ctx, "couldn't turn dead letter into json: %v", err.Error())
 			return err
@@ -267,7 +266,7 @@ func (ds *DeadletterService) RejectDeadMessage(ctx context.Context, req *dante_s
 			},
 		}
 
-		event_json, err := protojson.Marshal(&event)
+		event_json, err := ds.protojson.Marshal(&event)
 		if err != nil {
 			log.Infof(ctx, "couldn't turn dead letter event into json: %v", err.Error())
 			return err
@@ -322,7 +321,7 @@ func (ds *DeadletterService) ListDeadMessageEvents(ctx context.Context, req *dan
 			}
 
 			eproto := dante_pb.DeadMessageEvent{}
-			err := protojson.Unmarshal([]byte(event), &eproto)
+			err := ds.protojson.Unmarshal([]byte(event), &eproto)
 			if err != nil {
 				log.WithError(ctx, err).Error("Couldn't unmarshal dead letter event")
 				return err
@@ -384,7 +383,7 @@ func (ds *DeadletterService) GetDeadMessage(ctx context.Context, req *dante_spb.
 			}
 
 			eproto := dante_pb.DeadMessageEvent{}
-			err := protojson.Unmarshal([]byte(event), &eproto)
+			err := ds.protojson.Unmarshal([]byte(event), &eproto)
 			if err != nil {
 				log.WithError(ctx, err).Error("Couldn't unmarshal dead letter event")
 				return err
@@ -401,7 +400,7 @@ func (ds *DeadletterService) GetDeadMessage(ctx context.Context, req *dante_spb.
 	}
 
 	deadProto := dante_pb.DeadMessageState{}
-	err := protojson.Unmarshal([]byte(deadletter), &deadProto)
+	err := ds.protojson.Unmarshal([]byte(deadletter), &deadProto)
 	if err != nil {
 		log.WithError(ctx, err).Error("Couldn't unmarshal dead letter")
 		return nil, err
@@ -443,7 +442,7 @@ func (ds *DeadletterService) ListDeadMessages(ctx context.Context, req *dante_sp
 			}
 
 			deadProto := dante_pb.DeadMessageState{}
-			err = protojson.Unmarshal([]byte(deadJson), &deadProto)
+			err = ds.protojson.Unmarshal([]byte(deadJson), &deadProto)
 			if err != nil {
 				log.WithError(ctx, err).Error("Couldn't unmarshal dead letter")
 				return err

--- a/dynamictype/registry.go
+++ b/dynamictype/registry.go
@@ -1,0 +1,143 @@
+package dynamictype
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+type ProtoJSON struct {
+	protojson.MarshalOptions
+	protojson.UnmarshalOptions
+}
+
+type Resolver interface {
+	protoregistry.ExtensionTypeResolver
+	protoregistry.MessageTypeResolver
+}
+
+func NewProtoJSON(resolver Resolver) *ProtoJSON {
+	return &ProtoJSON{
+		MarshalOptions: protojson.MarshalOptions{
+			Resolver: resolver,
+		},
+		UnmarshalOptions: protojson.UnmarshalOptions{
+			Resolver: resolver,
+		},
+	}
+}
+
+func (pj ProtoJSON) Marshal(msg proto.Message) ([]byte, error) {
+	return pj.MarshalOptions.Marshal(msg)
+}
+
+func (pj ProtoJSON) Unmarshal(b []byte, msg proto.Message) error {
+	return pj.UnmarshalOptions.Unmarshal(b, msg)
+}
+
+type TypeRegistry struct {
+	messages map[string]protoreflect.MessageDescriptor
+
+	// leave nil, will panic if used.
+	protoregistry.ExtensionTypeResolver
+}
+
+func NewTypeRegistry() *TypeRegistry {
+	return &TypeRegistry{
+		messages: make(map[string]protoreflect.MessageDescriptor),
+	}
+}
+
+func (r *TypeRegistry) FindMessageByName(field protoreflect.FullName) (protoreflect.MessageType, error) {
+	descriptor, ok := r.messages[string(field)]
+	if !ok {
+		return nil, fmt.Errorf("couldn't find message by name: %s", field)
+	}
+
+	msg := dynamicpb.NewMessageType(descriptor)
+
+	return msg, nil
+}
+
+func (r *TypeRegistry) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	message := protoreflect.FullName(url)
+	if i := strings.LastIndexByte(url, '/'); i >= 0 {
+		message = message[i+len("/"):]
+	}
+	return r.FindMessageByName(message)
+}
+
+func (r *TypeRegistry) addMessage(msg protoreflect.MessageDescriptor) {
+	r.messages[string(msg.FullName())] = msg
+	subMessages := msg.Messages()
+	for idx := 0; idx < subMessages.Len(); idx++ {
+		r.addMessage(subMessages.Get(idx))
+	}
+}
+
+func (r *TypeRegistry) AddFileDescriptor(fds *descriptorpb.FileDescriptorSet) error {
+	fp, err := protodesc.NewFiles(fds)
+	if err != nil {
+		return fmt.Errorf("Couldn't convert to registry file: %v", err.Error())
+	}
+
+	fp.RangeFiles(func(a protoreflect.FileDescriptor) bool {
+		fileMessages := a.Messages()
+		for idx := 0; idx < fileMessages.Len(); idx++ {
+			msg := fileMessages.Get(idx)
+			r.addMessage(msg)
+		}
+
+		return true
+	})
+	return nil
+}
+
+func (r *TypeRegistry) LoadProtoFromFile(fileName string) error {
+	protoFile, err := os.ReadFile(fileName)
+	if err != nil {
+		return fmt.Errorf("couldn't read file: %v", err.Error())
+	}
+
+	fds := &descriptorpb.FileDescriptorSet{}
+	err = proto.Unmarshal(protoFile, fds)
+	if err != nil {
+		return fmt.Errorf("couldn't unmarshal file protofile: %v", err.Error())
+	}
+
+	return r.AddFileDescriptor(fds)
+}
+
+func (r *TypeRegistry) LoadExternalProtobufs(src string) error {
+	if len(src) == 0 {
+		return nil
+	}
+
+	res, err := http.Get(src)
+	if err != nil {
+		return fmt.Errorf("couldn't get file from %v: %v", src, err.Error())
+	}
+	body, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	if res.StatusCode > 299 {
+		return fmt.Errorf("got status code %v instead of 2xx", res.StatusCode)
+	}
+
+	fds := &descriptorpb.FileDescriptorSet{}
+	err = proto.Unmarshal(body, fds)
+	if err != nil {
+		return fmt.Errorf("couldn't unmarshal file protofile: %v", err.Error())
+	}
+
+	return r.AddFileDescriptor(fds)
+}

--- a/dynamictype/registry.go
+++ b/dynamictype/registry.go
@@ -128,7 +128,12 @@ func (r *TypeRegistry) LoadExternalProtobufs(src string) error {
 		return fmt.Errorf("couldn't get file from %v: %v", src, err.Error())
 	}
 	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		res.Body.Close()
+		return fmt.Errorf("couldn't read body: %v", err.Error())
+	}
 	res.Body.Close()
+
 	if res.StatusCode > 299 {
 		return fmt.Errorf("got status code %v instead of 2xx", res.StatusCode)
 	}

--- a/dynamictype/registry.go
+++ b/dynamictype/registry.go
@@ -77,11 +77,11 @@ func (r *TypeRegistry) FindMessageByURL(url string) (protoreflect.MessageType, e
 	return r.FindMessageByName(message)
 }
 
-func (r *TypeRegistry) addMessage(msg protoreflect.MessageDescriptor) {
+func (r *TypeRegistry) AddMessage(msg protoreflect.MessageDescriptor) {
 	r.messages[string(msg.FullName())] = msg
 	subMessages := msg.Messages()
 	for idx := 0; idx < subMessages.Len(); idx++ {
-		r.addMessage(subMessages.Get(idx))
+		r.AddMessage(subMessages.Get(idx))
 	}
 }
 
@@ -95,7 +95,7 @@ func (r *TypeRegistry) AddFileDescriptor(fds *descriptorpb.FileDescriptorSet) er
 		fileMessages := a.Messages()
 		for idx := 0; idx < fileMessages.Len(); idx++ {
 			msg := fileMessages.Get(idx)
-			r.addMessage(msg)
+			r.AddMessage(msg)
 		}
 
 		return true

--- a/dynamictype/registry_test.go
+++ b/dynamictype/registry_test.go
@@ -1,0 +1,93 @@
+package dynamictype
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/pentops/o5-go/dante/v1/dante_pb"
+	"github.com/pentops/o5-go/dante/v1/dante_tpb"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func TestDynamicLoad(t *testing.T) {
+
+	msgBase64 := "CgNmb28="
+	// a message with a single field, number 1, value is 'foo'
+
+	msgBytes, err := base64.StdEncoding.DecodeString(msgBase64)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dms := &dante_tpb.DeadMessage{
+		Payload: &dante_pb.Any{
+			Proto: &anypb.Any{
+				TypeUrl: "type.googleapis.com/namespace.v1.Foo",
+				Value:   msgBytes,
+			},
+		},
+	}
+
+	ps := &descriptorpb.FileDescriptorSet{}
+	outFile := &descriptorpb.FileDescriptorProto{
+		Name:    proto.String("namespace/v1/foo.proto"),
+		Package: proto.String("namespace.v1"),
+		MessageType: []*descriptorpb.DescriptorProto{{
+			Name: proto.String("Foo"),
+			Field: []*descriptorpb.FieldDescriptorProto{{
+				Name:     proto.String("field"),
+				Number:   proto.Int32(1),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				JsonName: proto.String("field"),
+			}},
+		}},
+	}
+	ps.File = append(ps.File, outFile)
+
+	types := NewTypeRegistry()
+	if err := types.AddFileDescriptor(ps); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	msg_json, err := protojson.MarshalOptions{
+		Resolver: types,
+	}.Marshal(dms)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("json: %s", string(msg_json))
+
+	content := map[string]interface{}{}
+	if err := json.Unmarshal(msg_json, &content); err != nil {
+		t.Fatal(err)
+	}
+	payload, ok := content["payload"].(map[string]interface{})
+	if !ok {
+		t.Fatal("payload not found")
+	}
+	proto, ok := payload["proto"].(map[string]interface{})
+	if !ok {
+		t.Fatal("proto not found")
+	}
+	type_url, ok := proto["@type"].(string)
+	if !ok {
+		t.Fatal("type_url not found")
+	}
+	if type_url != "type.googleapis.com/namespace.v1.Foo" {
+		t.Fatalf("type_url is not correct: %s", type_url)
+	}
+	value, ok := proto["field"].(string)
+	if !ok {
+		t.Fatal("field not found")
+	}
+	if value != "foo" {
+		t.Fatalf("field is not correct: %s", value)
+	}
+
+}


### PR DESCRIPTION
The go proto stuff is a pain to work with.
This *should* work, and allows the addition of some lazy loading if we want.

May require explicitly loading some types within dante, that can be done with
```golang
types.AddMessage((&dante_pb.DeadMessageState{}).ProtoReflect().Descriptor())
```

Briefly, the pain here is that a `ProtoReflect` message is a reflection wrapper around a concrete go implementation of the message. The Descriptor is just pure information about the proto type. Dynamicpb builds a runtime message purely out of a descriptor with no underlying go type.