### PR TITLE
Fix slack message sending for new dead letter

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -2,7 +2,7 @@ version: '2.4'
 
 services:
   database:
-    image: postgres:14.2-alpine
+    image: postgres:14.8-alpine
     environment:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: test

--- a/integration/dead_test.go
+++ b/integration/dead_test.go
@@ -122,7 +122,6 @@ func TestUpdate(tt *testing.T) {
 			t.Equal("new-queue-name", updated.Spec.QueueName)
 		}
 	})
-
 }
 
 func TestShelve(tt *testing.T) {

--- a/service/main.go
+++ b/service/main.go
@@ -368,8 +368,6 @@ type SlackMessage struct {
 }
 
 func (ds *DeadletterService) Dead(ctx context.Context, req *dante_tpb.DeadMessage) (*emptypb.Empty, error) {
-	rowInserted := false
-
 	s := dante_pb.DeadMessageSpec{
 		VersionId:      uuid.NewString(),
 		InfraMessageId: req.InfraMessageId,
@@ -433,7 +431,8 @@ func (ds *DeadletterService) Dead(ctx context.Context, req *dante_tpb.DeadMessag
 		return nil, err
 	}
 
-	if len(ds.slackUrl) > 0 && rowInserted {
+	// if we got here, no error occurred so we inserted a new dead letter, let slack know
+	if len(ds.slackUrl) > 0 {
 		msg := SlackMessage{}
 		wrapper := `*Deadletter on*:
 %v


### PR DESCRIPTION
This didn't work after the update to using PSM. Now it should work again.